### PR TITLE
Code quality fix - The members of an interface declaration or class should appear in a pre-defined order.

### DIFF
--- a/app/src/main/java/com/tekinarslan/material/sample/Button.java
+++ b/app/src/main/java/com/tekinarslan/material/sample/Button.java
@@ -30,6 +30,11 @@ public abstract class Button extends RelativeLayout {
     OnClickListener onClickListener;
     int backgroundColor = Color.parseColor("#1E88E5");
 
+
+    // ### RIPPLE EFFECT ###
+    float x = -1, y = -1;
+    float radius = -1;
+
     public Button(Context context, AttributeSet attrs) {
         super(context, attrs);
         setDefaultProperties();
@@ -48,11 +53,6 @@ public abstract class Button extends RelativeLayout {
     }
     // Set atributtes of XML to View
 
-
-    // ### RIPPLE EFFECT ###
-
-    float x = -1, y = -1;
-    float radius = -1;
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {

--- a/app/src/main/java/com/tekinarslan/material/sample/ProgressBarCircular.java
+++ b/app/src/main/java/com/tekinarslan/material/sample/ProgressBarCircular.java
@@ -20,6 +20,15 @@ public class ProgressBarCircular extends RelativeLayout {
 
     int backgroundColor = Color.parseColor("#1E88E5");
 
+    float radius1 = 0;
+    float radius2 = 0;
+    int cont = 0;
+    boolean firstAnimationOver = false;
+    
+    int arcD = 1;
+    int arcO = 0;
+    float rotateAngle = 0;
+    int limite = 0;
 
     public ProgressBarCircular(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -84,11 +93,6 @@ public class ProgressBarCircular extends RelativeLayout {
 
     }
 
-    float radius1 = 0;
-    float radius2 = 0;
-    int cont = 0;
-    boolean firstAnimationOver = false;
-
     /**
      * Draw first animation of view
      *
@@ -125,11 +129,6 @@ public class ProgressBarCircular extends RelativeLayout {
                 firstAnimationOver = true;
         }
     }
-
-    int arcD = 1;
-    int arcO = 0;
-    float rotateAngle = 0;
-    int limite = 0;
 
     /**
      * Draw second animation of view


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.

Faisal Hameed